### PR TITLE
Refactor main POM to BOM and update the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,18 +15,29 @@ This package requires Java 17 or later.
 Install using Maven by adding the following to your `pom.xml`:
 
 ```xml
-<dependency>
-    <groupId>com.starfederation</groupId>
-    <artifactId>datastar</artifactId>
-    <version>1.0.0</version>
-</dependency>
+<dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>dev.data-star</groupId>
+            <artifactId>datastar-java-sdk</artifactId>
+            <version>1.0.0</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+    </dependencies>
+</dependencyManagement>
 
-<repositories>
-    <repository>
-        <id>github</id>
-        <url>https://maven.pkg.github.com/starfederation/datastar</url>
-    </repository>
-</repositories>
+<dependencies>
+  <dependency>
+    <groupId>dev.data-star</groupId>
+    <artifactId>datastar-java-sdk-core</artifactId>
+  </dependency>
+  <!-- If needed  (JAX-RS adapter) -->
+  <dependency>
+      <groupId>dev.data-star</groupId>
+      <artifactId>datastar-java-sdk-jaxrs</artifactId>
+  </dependency>
+</dependencies>
 ```
 
 ## Usage

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>dev.data-star</groupId>

--- a/datastar-java-sdk-jaxrs/pom.xml
+++ b/datastar-java-sdk-jaxrs/pom.xml
@@ -1,18 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>datastar-java-sdk-jaxrs</artifactId>
-    <version>1.0.0</version>
-    <packaging>jar</packaging>
     <parent>
         <groupId>dev.data-star</groupId>
         <artifactId>datastar-java-sdk</artifactId>
         <version>1.0.0</version>
     </parent>
+    <artifactId>datastar-java-sdk-jaxrs</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
 
-    <name>Datastar Java SDK JAX-RS plugin </name>
+    <name>Datastar Java SDK JAX-RS plugin</name>
     <description>JAX-RS plugin for the Datastar SDK</description>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>dev.data-star</groupId>
@@ -12,10 +11,13 @@
     <description>A Java SDK for Datastar.</description>
     <url>https://github.com/starfederation/datastar-java</url>
 
-    <modules>
-        <module>core</module>
-        <module>datastar-java-sdk-jaxrs</module>
-    </modules>
+    <licenses>
+        <license>
+            <name>MIT</name>
+            <url>https://mit-license.org/</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
 
     <developers>
         <developer>
@@ -27,30 +29,27 @@
         </developer>
     </developers>
 
-    <licenses>
-        <license>
-            <name>MIT</name>
-            <distribution>repo</distribution>
-            <url>https://mit-license.org/</url>
-        </license>
-    </licenses>
-
-    <distributionManagement>
-        <snapshotRepository>
-            <id>central</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-        <repository>
-            <id>central</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
-    </distributionManagement>
+    <modules>
+        <module>core</module>
+        <module>datastar-java-sdk-jaxrs</module>
+    </modules>
 
     <scm>
         <connection>scm:git:https://github.com/starfederation/datastar-java.git</connection>
         <developerConnection>scm:git:https://github.com/starfederation/datastar-java.git</developerConnection>
         <url>https://github.com/starfederation/datastar-java</url>
     </scm>
+
+    <distributionManagement>
+        <repository>
+            <id>central</id>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+        <snapshotRepository>
+            <id>central</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+    </distributionManagement>
 
     <properties>
         <maven.compiler.release>17</maven.compiler.release>
@@ -69,72 +68,23 @@
         <mockito.version>5.14.2</mockito.version>
         <jackson.databind.version>2.18.2</jackson.databind.version>
     </properties>
+    <dependencyManagement>
+        <dependencies>
+            <!-- Core SDK -->
+            <dependency>
+                <groupId>dev.data-star</groupId>
+                <artifactId>datastar-java-sdk-core</artifactId>
+                <version>${project.version}</version>
+            </dependency>
 
-    <profiles>
-        <profile>
-            <id>deploy</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.sonatype.central</groupId>
-                        <artifactId>central-publishing-maven-plugin</artifactId>
-                        <version>0.8.0</version>
-                        <extensions>true</extensions>
-                        <configuration>
-                            <publishingServerId>central</publishingServerId>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-gpg-plugin</artifactId>
-                        <version>${maven.gpg.plugin.version}</version>
-                        <executions>
-                            <execution>
-                                <id>sign-artifacts</id>
-                                <phase>verify</phase>
-                                <goals>
-                                    <goal>sign</goal>
-                                </goals>
-                                <configuration>
-                                    <gpgArguments>
-                                        <arg>--pinentry-mode</arg>
-                                        <arg>loopback</arg>
-                                    </gpgArguments>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>${maven.javadoc.plugin.version}</version>
-                        <executions>
-                            <execution>
-                                <id>attach-javadocs</id>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>jar</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-source-plugin</artifactId>
-                        <version>${maven.source.plugin.version}</version>
-                        <executions>
-                            <execution>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>jar</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
+            <!-- JAX-RS extension -->
+            <dependency>
+                <groupId>dev.data-star</groupId>
+                <artifactId>datastar-java-sdk-jaxrs</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>
@@ -184,12 +134,77 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven.surefire.plugin.version}</version>
                 <configuration>
-                    <argLine>
-                        -javaagent:@{org.mockito:mockito-core:jar}
+                    <argLine>-javaagent:@{org.mockito:mockito-core:jar}
                         -Xshare:off
                     </argLine>
                 </configuration>
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>deploy</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.8.0</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <publishingServerId>central</publishingServerId>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>${maven.gpg.plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                                <phase>verify</phase>
+                                <configuration>
+                                    <gpgArguments>
+                                        <arg>--pinentry-mode</arg>
+                                        <arg>loopback</arg>
+                                    </gpgArguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>${maven.javadoc.plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                                <phase>package</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <version>${maven.source.plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                                <phase>package</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
This PR does the following 

1. It updates the readme to align it with recent changes (publishing to maven central).
2. It makes the main project into a BOM, meaning all versions of core and adapters will be fetched from our published pom artifact, for easier dependency management on the user side.
3. It makes the source and docs generation use no-fork to avoid running part of the build several times (see maven docs for reference).
4. It reorders the attributes of all pom files as per the maven spec.