### PR TITLE
IO simplification

### DIFF
--- a/core/src/main/java/starfederation/datastar/utils/SignalReader.java
+++ b/core/src/main/java/starfederation/datastar/utils/SignalReader.java
@@ -37,12 +37,9 @@ public class SignalReader {
             }
         } else {
             // Handle other methods by reading the request body
-            StringBuilder requestBody = new StringBuilder();
+            StringWriter requestBody = new StringWriter();
             try (BufferedReader reader = requestAdapter.getReader()) {
-                String line;
-                while ((line = reader.readLine()) != null) {
-                    requestBody.append(line);
-                }
+                reader.transferTo(requestBody);
             }
 
             data = requestBody.toString();

--- a/core/src/main/java/starfederation/datastar/utils/SignalReader.java
+++ b/core/src/main/java/starfederation/datastar/utils/SignalReader.java
@@ -6,6 +6,7 @@ import starfederation.datastar.adapters.request.RequestAdapter;
 
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.StringWriter;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentMap;

--- a/core/src/main/java/starfederation/datastar/utils/SignalReader.java
+++ b/core/src/main/java/starfederation/datastar/utils/SignalReader.java
@@ -4,9 +4,10 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import starfederation.datastar.adapters.request.RequestAdapter;
 
-import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.Reader;
 import java.io.StringWriter;
+import java.io.Writer;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentMap;
@@ -38,12 +39,10 @@ public class SignalReader {
             }
         } else {
             // Handle other methods by reading the request body
-            StringWriter requestBody = new StringWriter();
-            try (BufferedReader reader = requestAdapter.getReader()) {
-                reader.transferTo(requestBody);
+            try (Reader reader = requestAdapter.getReader(); Writer writer = new StringWriter()) {
+                reader.transferTo(writer);
+                data = writer.toString();
             }
-
-            data = requestBody.toString();
             if (data.isEmpty()) {
                 throw new IllegalArgumentException("Request body cannot be empty.");
             }

--- a/examples/hello-world/src/main/java/org/example/servlets/HtmlServlet.java
+++ b/examples/hello-world/src/main/java/org/example/servlets/HtmlServlet.java
@@ -23,10 +23,7 @@ public class HtmlServlet extends HttpServlet {
 
         try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));
              PrintWriter writer = resp.getWriter()) {
-            String line;
-            while ((line = reader.readLine()) != null) {
-                writer.println(line);
-            }
+            reader.transferTo(writer);
         }
     }
 }

--- a/examples/hello-world/src/main/java/org/example/servlets/HtmlServlet.java
+++ b/examples/hello-world/src/main/java/org/example/servlets/HtmlServlet.java
@@ -21,9 +21,8 @@ public class HtmlServlet extends HttpServlet {
 
         resp.setContentType("text/html;charset=UTF-8");
 
-        try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));
-             PrintWriter writer = resp.getWriter()) {
-            reader.transferTo(writer);
+        try (inputStream; OutputStream output = resp.getOutputStream()) {
+            inputStream.transferTo(output);
         }
     }
 }


### PR DESCRIPTION
There doesn't seem to be a reason to do IO line by line, so replace with `transferTo` alternative (available since Java 10).