### PR TITLE
fixed hello-world example

### DIFF
--- a/examples/hello-world/pom.xml
+++ b/examples/hello-world/pom.xml
@@ -14,7 +14,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <jetty.version>12.1.9</jetty.version>
+    <jetty.version>12.1.11</jetty.version>
     <maven.compiler.source>21</maven.compiler.source>
     <maven.compiler.target>21</maven.compiler.target>
   </properties>

--- a/examples/hello-world/pom.xml
+++ b/examples/hello-world/pom.xml
@@ -45,11 +45,6 @@
       <artifactId>logback-classic</artifactId>
       <version>1.5.32</version>
     </dependency>
-    <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
-      <version>6.1.0</version>
-    </dependency>
   </dependencies>
 
   <build>

--- a/examples/hello-world/pom.xml
+++ b/examples/hello-world/pom.xml
@@ -34,13 +34,11 @@
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
       <version>${jetty.version}</version>
-      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.ee10</groupId>
       <artifactId>jetty-ee10-servlet</artifactId>
       <version>${jetty.version}</version>
-      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>

--- a/examples/hello-world/pom.xml
+++ b/examples/hello-world/pom.xml
@@ -43,7 +43,7 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.5.32</version>
+      <version>1.5.38</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
The example wasn't compiling because jetty depenencies weren't present in the classpath at compile time.

While at it, went through the other dependencies.